### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/datasette.yml
+++ b/.github/workflows/datasette.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v4.1.1
 
       - name: Set up Python
-        uses: actions/setup-python@v4.6.0
+        uses: actions/setup-python@v4.7.1
         with:
           python-version: '3.8'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,11 +19,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v4.1.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}
-      - uses: actions/cache@v3.3.1
+      - uses: actions/cache@v3.3.2
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -31,7 +31,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Set up Python
-        uses: actions/setup-python@v4.6.0
+        uses: actions/setup-python@v4.7.1
         with:
           python-version: 3.10.11
 
@@ -40,4 +40,4 @@ jobs:
 
       - name: Run Archiver
         run: python tn_gazette_archiver.py
-      - uses: stefanzweifel/git-auto-commit-action@v4.16.0
+      - uses: stefanzweifel/git-auto-commit-action@v5.0.0

--- a/.github/workflows/workflow_updater.yml
+++ b/.github/workflows/workflow_updater.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.5.2
+      - uses: actions/checkout@v4.1.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.4
+        uses: saadmk11/github-actions-version-updater@v0.8.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1)** on 2023-10-17T15:53:17Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.1)** on 2023-08-13T13:53:59Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.7.1](https://github.com/actions/setup-python/releases/tag/v4.7.1)** on 2023-10-02T10:59:39Z
* **[stefanzweifel/git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action)** published a new release **[v5.0.0](https://github.com/stefanzweifel/git-auto-commit-action/releases/tag/v5.0.0)** on 2023-10-06T17:55:00Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.3.2](https://github.com/actions/cache/releases/tag/v3.3.2)** on 2023-09-07T20:33:08Z
